### PR TITLE
Give selinux pcp_pmcd_t type manage access to /var/lib/docker

### DIFF
--- a/docker.te
+++ b/docker.te
@@ -452,3 +452,10 @@ optional_policy(`
 		auth_use_nsswitch(systemd_machined_t)
 	')
 ')
+
+optional_policy(`
+	gen_require(`
+		type pcp_pmcd_t;
+	')
+	docker_manage_lib_files(pcp_pmcd_t)
+')


### PR DESCRIPTION
Signed-off-by: Kenfe-Mickael Laventure mickael.laventure@gmail.com

---

This import this [fix](https://github.com/fedora-cloud/docker-selinux/commit/d9b8b854ad7d3cf264c0d06362e3552a04f26998).

My only question is why does pcp_pmcd also need write access to `/var/lib/docker`, could this use `docker_read_lib_files` instead?

ping @rhatdan 
