### PR TITLE
Fix labeling for docker-latest

### DIFF
--- a/container.fc
+++ b/container.fc
@@ -16,23 +16,22 @@
 /etc/docker-latest(/.*)?		gen_context(system_u:object_r:container_config_t,s0)
 
 /var/lib/docker(/.*)?		gen_context(system_u:object_r:container_var_lib_t,s0)
+/var/lib/docker/.*/config\.env	gen_context(system_u:object_r:container_share_t,s0)
+/var/lib/docker/containers/.*/.*\.log		gen_context(system_u:object_r:container_log_t,s0)
+/var/lib/docker/containers/.*/hostname		gen_context(system_u:object_r:container_share_t,s0)
+/var/lib/docker/containers/.*/hosts		gen_context(system_u:object_r:container_share_t,s0)
+/var/lib/docker/init(/.*)?		gen_context(system_u:object_r:container_share_t,s0)
 /var/lib/docker/overlay(/.*)?	gen_context(system_u:object_r:container_share_t,s0)
 /var/lib/docker/overlay2(/.*)?	gen_context(system_u:object_r:container_share_t,s0)
 
-/var/lib/docker/init(/.*)?		gen_context(system_u:object_r:container_share_t,s0)
-/var/lib/docker-latest/init(/.*)?		gen_context(system_u:object_r:container_share_t,s0)
-
-/var/lib/docker/containers/.*/hosts		gen_context(system_u:object_r:container_share_t,s0)
-/var/lib/docker-latest/containers/.*/hosts		gen_context(system_u:object_r:container_share_t,s0)
-
-/var/lib/docker/containers/.*/hostname		gen_context(system_u:object_r:container_share_t,s0)
-/var/lib/docker-latest/containers/.*/hostname		gen_context(system_u:object_r:container_share_t,s0)
-
-/var/lib/docker/containers/.*/.*\.log		gen_context(system_u:object_r:container_log_t,s0)
-/var/lib/docker-latest/containers/.*/.*\.log	gen_context(system_u:object_r:container_log_t,s0)
-
-/var/lib/docker/.*/config\.env	gen_context(system_u:object_r:container_share_t,s0)
+/var/lib/docker-latest(/.*)?		gen_context(system_u:object_r:container_var_lib_t,s0)
 /var/lib/docker-latest/.*/config\.env	gen_context(system_u:object_r:container_share_t,s0)
+/var/lib/docker-latest/containers/.*/.*\.log	gen_context(system_u:object_r:container_log_t,s0)
+/var/lib/docker-latest/containers/.*/hostname		gen_context(system_u:object_r:container_share_t,s0)
+/var/lib/docker-latest/containers/.*/hosts		gen_context(system_u:object_r:container_share_t,s0)
+/var/lib/docker-latest/init(/.*)?		gen_context(system_u:object_r:container_share_t,s0)
+/var/lib/docker-latest/overlay(/.*)?	gen_context(system_u:object_r:container_share_t,s0)
+/var/lib/docker-latest/overlay2(/.*)?	gen_context(system_u:object_r:container_share_t,s0)
 
 /var/run/docker(/.*)?		gen_context(system_u:object_r:container_var_run_t,s0)
 /var/run/containerd(/.*)?	gen_context(system_u:object_r:container_var_run_t,s0)

--- a/container.te
+++ b/container.te
@@ -128,7 +128,12 @@ manage_files_pattern(container_runtime_t, container_share_t, container_share_t)
 manage_lnk_files_pattern(container_runtime_t, container_share_t, container_share_t)
 allow container_runtime_t container_share_t:dir_file_class_set { relabelfrom relabelto };
 can_exec(container_runtime_t, container_share_t)
+filetrans_pattern(container_runtime_t, container_var_lib_t, container_share_t, dir, "init")
 filetrans_pattern(container_runtime_t, container_var_lib_t, container_share_t, dir, "overlay")
+filetrans_pattern(container_runtime_t, container_var_lib_t, container_share_t, dir, "overlay2")
+filetrans_pattern(container_runtime_t, container_var_lib_t, container_share_t, file, "config.env")
+filetrans_pattern(container_runtime_t, container_var_lib_t, container_share_t, file, "hostname")
+filetrans_pattern(container_runtime_t, container_var_lib_t, container_share_t, file, "hosts")
 
 #container_filetrans_named_content(container_runtime_t)
 


### PR DESCRIPTION
Create directories under /var/lib/docker* with the correct label.


@rhatdan just cherry-picked your latest master commit to RHEL-1.12