### PR TITLE
Create docker_t alias optionally

### DIFF
--- a/container.te
+++ b/container.te
@@ -20,8 +20,10 @@ gen_tunable(container_connect_any, false)
 ## </desc>
 gen_tunable(container_manage_cgroup, false)
 
-type container_runtime_t alias docker_t;
-type container_runtime_exec_t alias docker_exec_t;
+optional_policy(`
+	type container_runtime_t alias docker_t;
+	type container_runtime_exec_t alias docker_exec_t;
+')
 init_daemon_domain(container_runtime_t, container_runtime_exec_t)
 domain_subj_id_change_exemption(container_runtime_t)
 domain_role_change_exemption(container_runtime_t)


### PR DESCRIPTION
In Foreman and Satellite 6 product we are shipping `docker_port_t` but since
docker policy was renamed and this port definition is now an alias, we are
running into issue when this package is installed or updated after
foreman-selinux (Satellite 6) package.

Since the type `docker_port_t` already exists, we are getting:

```
 Re-declaration of type docker_port_t
 Failed to create node
 Bad type declaration at /etc/selinux/targeted/tmp/modules/400/foreman/cil:27
 /usr/sbin/semodule:  Failed!
```

This patch is a proposal to make this optional, so it loads fine. I haven't
tested this myself, but I believe this is valid SELinux syntax and it should
help in our case.