### PR TITLE
substitute undefined interfaces with fedora defs

### DIFF
--- a/container.te
+++ b/container.te
@@ -109,8 +109,18 @@ filetrans_pattern(container_runtime_t, container_var_lib_t, container_log_t, fil
 allow container_runtime_t { container_var_lib_t container_share_t }:file entrypoint;
 # Added to make typebounds check work.
 # Hopefully can remove when we have a better solution
-files_entrypoint_all_mountpoint(container_runtime_t)
-corecmd_entrypoint_all_executables(container_runtime_t)
+
+#files_entrypoint_all_mountpoint(container_runtime_t)
+gen_require(`
+        attribute mountpoint;
+')
+allow container_runtime_t mountpoint:file entrypoint;
+
+#corecmd_entrypoint_all_executables(container_runtime_t)
+gen_require(`
+        attribute exec_type;
+')
+allow container_runtime_t exec_type:file entrypoint;
 
 manage_dirs_pattern(container_runtime_t, container_runtime_tmp_t, container_runtime_tmp_t)
 manage_files_pattern(container_runtime_t, container_runtime_tmp_t, container_runtime_tmp_t)


### PR DESCRIPTION
files_entrypoint_all_mountpoint and corecmd_entrypoint_all_executables are not
included yet in RHEL's selinux-policy. This commit substitutes them in place
with their fedora defs to allow builds to succeed.

Signed-off-by: Lokesh Mandvekar <lsm5@redhat.com>


@rhatdan ptal, this fixes build issues on RHEL 7