### PR TITLE
Give container_t access to XFRM sockets

### DIFF
--- a/container.te
+++ b/container.te
@@ -602,6 +602,7 @@ allow container_t self:packet_socket create_socket_perms;
 allow container_t self:socket create_socket_perms;
 allow container_t self:rawip_socket create_stream_socket_perms;
 allow container_t self:netlink_kobject_uevent_socket create_socket_perms;
+allow container_t self:netlink_xfrm_socket create_netlink_socket_perms;
 manage_chr_files_pattern(container_t, container_file_t, container_file_t)
 manage_blk_files_pattern(container_t, container_file_t, container_file_t)
 


### PR DESCRIPTION
Unprivileged containers cannot currently access XFRM sockets. This is causing issues for Rancher users running on RHEL or CentOS with SELinux enabled due to Rancher's IPsec network implementation.

Unfortunately I'm not familiar enough with SELinux to determine whether unprivileged containers should have these permissions in general. I see the same permissions on similar socket types so it doesn't seem too unreasonable, but I'm still interested to hear feedback on this.

cc @ibuildthecloud